### PR TITLE
Allow more information for casting

### DIFF
--- a/src/_column-matches.js
+++ b/src/_column-matches.js
@@ -21,7 +21,7 @@ const _columnMatches = ({
     return false;
   }
   // Pick resolved value by convention
-  const resolvedValue = castingStrategy(value);
+  const resolvedValue = castingStrategy(value, column);
 
   return strategy(transform(query)).evaluate(transform(resolvedValue));
 };


### PR DESCRIPTION
By adding the column info to the castingStrategy call, we can have better control over casting as we know which type of data is being cast.