### PR TITLE
Add toggle for rendering search input in columns

### DIFF
--- a/src/components/search-columns.js
+++ b/src/components/search-columns.js
@@ -13,7 +13,7 @@ const SearchColumns = ({ columns, query, onChange }) => {
     <tr>
       {columns.map((column, i) => (
         <th key={`${column.property || i}-column-filter`} className="column-filter">
-          {column && column.property ?
+          {(column && column.property) && (!('filterable' in column) || column.filterable) ?
             <input
               onChange={onQueryChange}
               className="column-filter-input"


### PR DESCRIPTION
Apologies in advance since I'm not much of a React/Javascript guy.

**Problem:**
Using <search.Columns> in conjunction with reactabular will cause every column to render a search input field, regardless of whether or not you would like that column to be searchable.

**This PR Addresses It By:**
We examine the column object to check for a "filterable" property.  For backwards compatibility, if the property doesn't exist, the search input field is rendered as usual.  If the property does exist and it's value is true, we render if the search input field as usual.  If the property exists and is set to false, we do not render the search input field.

I welcome any and all feedback.  Thanks for your time and hard work on this library.  